### PR TITLE
feat: customize cotton_django as dj_component with <dj-button> templa…

### DIFF
--- a/dj_component/apps.py
+++ b/dj_component/apps.py
@@ -1,0 +1,88 @@
+"""
+django-cotton
+
+App configuration to set up the cotton loader and builtins automatically.
+"""
+import re
+from contextlib import suppress
+
+import django.contrib.admin
+import django.template
+from django.apps import AppConfig
+from django.conf import settings
+
+
+def wrap_loaders(name):
+    for template_config in settings.TEMPLATES:
+        engine_name = template_config.get("NAME")
+        if not engine_name:
+            engine_name = template_config["BACKEND"].split(".")[-2]
+        if engine_name == name:
+            loaders = template_config.setdefault("OPTIONS", {}).get("loaders", [])
+
+            loaders_already_configured = (
+                loaders
+                and isinstance(loaders, (list, tuple))
+                and isinstance(loaders[0], (tuple, list))
+                and loaders[0][0] == "django.template.loaders.cached.Loader"
+                and "dj_component.cotton_loader.Loader" in loaders[0][1]
+            )
+
+            if not loaders_already_configured:
+                template_config.pop("APP_DIRS", None)
+                default_loaders = [
+                    "dj_component.cotton_loader.Loader",
+                    "django.template.loaders.filesystem.Loader",
+                    "django.template.loaders.app_directories.Loader",
+                ]
+                cached_loaders = [("django.template.loaders.cached.Loader", default_loaders)]
+                template_config["OPTIONS"]["loaders"] = cached_loaders
+
+            options = template_config.setdefault("OPTIONS", {})
+            builtins = options.setdefault("builtins", [])
+            builtins_already_configured = (
+                builtins and "dj_component.templatetags.cotton" in builtins
+            )
+            if not builtins_already_configured:
+                template_config["OPTIONS"]["builtins"].insert(
+                    0, "dj_component.templatetags.cotton"
+                )
+
+            break
+
+    # Force re-evaluation of settings.TEMPLATES because EngineHandler caches it.
+    with suppress(AttributeError):
+        del django.template.engines.templates
+        django.template.engines._engines = {}
+
+
+class LoaderAppConfig(AppConfig):
+    """
+    This, the default configuration, does the automatic setup of a partials loader.
+    """
+
+    name = "dj_component"
+    default = True
+
+    def ready(self):
+        from django.template import base
+
+        # Support for multiline tags
+        base.tag_re = re.compile(base.tag_re.pattern, re.DOTALL)
+
+        wrap_loaders("django")
+
+
+class SimpleAppConfig(AppConfig):
+    """
+    This, the non-default configuration, allows the user to opt-out of the automatic configuration. They just need to
+    add "dj_component.apps.SimpleAppConfig" to INSTALLED_APPS instead of "dj_component".
+    """
+
+    name = "dj_component"
+
+    def ready(self):
+        from django.template import base
+
+        # Support for multiline tags
+        base.tag_re = re.compile(base.tag_re.pattern, re.DOTALL)

--- a/dj_component/compiler_regex.py
+++ b/dj_component/compiler_regex.py
@@ -1,0 +1,155 @@
+import re
+from typing import List, Tuple
+
+
+class Tag:
+    tag_pattern = re.compile(
+        r"<(/?)dj-([^\s/>]+)((?:\s+[^\s/>\"'=<>`]+(?:\s*=\s*(?:\"[^\"]*\"|'[^']*'|\S+))?)*)\s*(/?)\s*>",
+        re.DOTALL,
+    )
+    attr_pattern = re.compile(r'([^\s/>\"\'=<>`]+)(?:\s*=\s*(?:(["\'])(.*?)\2|(\S+)))?', re.DOTALL)
+
+    def __init__(self, match: re.Match):
+        self.html = match.group(0)
+        self.tag_name = f"dj-{match.group(2)}"
+        self.attrs = match.group(3) or ""
+        self.is_closing = bool(match.group(1))
+        self.is_self_closing = bool(match.group(4))
+
+    def get_template_tag(self) -> str:
+        """Convert a cotton tag to a Django template tag"""
+        if self.tag_name == "dj-vars":
+            return ""  # c-vars tags will be handled separately
+        elif self.tag_name == "dj-slot":
+            return self._process_slot()
+        elif self.tag_name.startswith("dj-"):
+            return self._process_component()
+        else:
+            return self.html
+
+    def _process_slot(self) -> str:
+        """Convert a c-slot tag to a Django template slot tag"""
+        if self.is_closing:
+            return "{% endslot %}"
+        name_match = re.search(r'name=(["\'])(.*?)\1', self.attrs, re.DOTALL)
+        if not name_match:
+            raise ValueError(f"c-slot tag must have a name attribute: {self.html}")
+        slot_name = name_match.group(2)
+        return f"{{% slot {slot_name} %}}"
+
+    def _process_component(self) -> str:
+        """Convert a c- component tag to a Django template component tag"""
+        component_name = self.tag_name[3:]
+        if self.is_closing:
+            return "{% endc %}"
+        processed_attrs, extracted_attrs = self._process_attributes()
+        opening_tag = f"{{% c {component_name}{processed_attrs} %}}"
+        if self.is_self_closing:
+            return f"{opening_tag}{extracted_attrs}{{% endc %}}"
+        return f"{opening_tag}{extracted_attrs}"
+
+    def _process_attributes(self) -> Tuple[str, str]:
+        """Move any complex attributes to the {% attr %} tag"""
+        processed_attrs = []
+        extracted_attrs = []
+
+        for match in self.attr_pattern.finditer(self.attrs):
+            key, quote, value, unquoted_value = match.groups()
+            if value is None and unquoted_value is None:
+                processed_attrs.append(key)
+            else:
+                actual_value = value if value is not None else unquoted_value
+                if any(s in actual_value for s in ("{{", "{%", "=", "__COTTON_IGNORE_")):
+                    extracted_attrs.append(f"{{% attr {key} %}}{actual_value}{{% endattr %}}")
+                else:
+                    processed_attrs.append(f'{key}="{actual_value}"')
+
+        return " " + " ".join(processed_attrs), "".join(extracted_attrs)
+
+
+class CottonCompiler:
+    def __init__(self):
+        self.c_vars_pattern = re.compile(r"<dj-vars\s([^>]*)(?:/>|>(.*?)</dj-vars>)", re.DOTALL)
+        self.ignore_pattern = re.compile(
+            # cotton_verbatim isnt a real template tag, it's just a way to ignore <c-* tags from being compiled
+            r"({%\s*cotton_verbatim\s*%}.*?{%\s*endcotton_verbatim\s*%}|"
+            # Ignore both forms of comments
+            r"{%\s*comment\s*%}.*?{%\s*endcomment\s*%}|{#.*?#}|"
+            # Ignore django template tags and variables
+            r"{{.*?}}|{%.*?%})",
+            re.DOTALL,
+        )
+        self.cotton_verbatim_pattern = re.compile(
+            r"{%\s*cotton_verbatim\s*%}(.*?){%\s*endcotton_verbatim\s*%}", re.DOTALL
+        )
+
+    def exclude_ignorables(self, html: str) -> Tuple[str, List[Tuple[str, str]]]:
+        ignorables = []
+
+        def replace_ignorable(match):
+            placeholder = f"__COTTON_IGNORE_{len(ignorables)}__"
+            ignorables.append((placeholder, match.group(0)))
+            return placeholder
+
+        processed_html = self.ignore_pattern.sub(replace_ignorable, html)
+        return processed_html, ignorables
+
+    def restore_ignorables(self, html: str, ignorables: List[Tuple[str, str]]) -> str:
+        for placeholder, content in ignorables:
+            if content.strip().startswith("{% cotton_verbatim %}"):
+                # Extract content between cotton_verbatim tags, we don't want to leave these in
+                match = self.cotton_verbatim_pattern.search(content)
+                if match:
+                    content = match.group(1)
+            html = html.replace(placeholder, content)
+        return html
+
+    def get_replacements(self, html: str) -> List[Tuple[str, str]]:
+        replacements = []
+        for match in Tag.tag_pattern.finditer(html):
+            tag = Tag(match)
+            try:
+                template_tag = tag.get_template_tag()
+                if template_tag != tag.html:
+                    replacements.append((tag.html, template_tag))
+            except ValueError as e:
+                # Find the line number of the error
+                position = match.start()
+                line_number = html[:position].count("\n") + 1
+                raise ValueError(f"Error in template at line {line_number}: {str(e)}") from e
+
+        return replacements
+
+    def process_c_vars(self, html: str) -> Tuple[str, str]:
+        """
+        Extract c-vars content and remove c-vars tags from the html.
+        Raises ValueError if more than one c-vars tag is found.
+        """
+        # Find all matches of c-vars tags
+        matches = list(self.c_vars_pattern.finditer(html))
+
+        if len(matches) > 1:
+            raise ValueError(
+                "Multiple c-vars tags found in component template. Only one c-vars tag is allowed per template."
+            )
+
+        # Process single c-vars tag if present
+        match = matches[0] if matches else None
+        if match:
+            attrs = match.group(1)
+            vars_content = f"{{% vars {attrs.strip()} %}}"
+            html = self.c_vars_pattern.sub("", html)  # Remove all c-vars tags
+            return vars_content, html
+
+        return "", html
+
+    def process(self, html: str) -> str:
+        """Putting it all together"""
+        processed_html, ignorables = self.exclude_ignorables(html)
+        vars_content, processed_html = self.process_c_vars(processed_html)
+        replacements = self.get_replacements(processed_html)
+        for original, replacement in replacements:
+            processed_html = processed_html.replace(original, replacement)
+        if vars_content:
+            processed_html = f"{vars_content}{processed_html}{{% endvars %}}"
+        return self.restore_ignorables(processed_html, ignorables)

--- a/dj_component/cotton_loader.py
+++ b/dj_component/cotton_loader.py
@@ -1,0 +1,126 @@
+import hashlib
+import os
+from functools import lru_cache
+
+from django.conf import settings
+from django.template.loaders.base import Loader as BaseLoader
+from django.core.exceptions import SuspiciousFileOperation
+from django.template import TemplateDoesNotExist, Origin
+from django.utils._os import safe_join
+from django.template import Template
+from django.apps import apps
+
+from dj_component.compiler_regex import CottonCompiler
+
+
+class Loader(BaseLoader):
+    def __init__(self, engine, dirs=None):
+        super().__init__(engine)
+        self.cotton_compiler = CottonCompiler()
+        self.cache_handler = CottonTemplateCacheHandler()
+        self.dirs = dirs
+
+    def get_contents(self, origin):
+        cache_key = self.cache_handler.get_cache_key(origin)
+        cached_content = self.cache_handler.get_cached_template(cache_key)
+
+        if cached_content is not None:
+            return cached_content
+
+        template_string = self._get_template_string(origin.name)
+
+        if "<dj-" not in template_string and "{% cotton_verbatim" not in template_string:
+            compiled = template_string
+        else:
+            compiled = self.cotton_compiler.process(template_string)
+
+        self.cache_handler.cache_template(cache_key, compiled)
+
+        return compiled
+
+    def get_template_from_string(self, template_string):
+        """Create and return a Template object from a string. Used primarily for testing."""
+        return Template(template_string, engine=self.engine)
+
+    def _get_template_string(self, template_name):
+        try:
+            with open(template_name, "r", encoding=self.engine.file_charset) as f:
+                return f.read()
+        except FileNotFoundError:
+            raise TemplateDoesNotExist(template_name)
+
+    @lru_cache(maxsize=None)
+    def get_dirs(self):
+        """Retrieves possible locations of cotton directory"""
+        dirs = list(self.dirs or self.engine.dirs)
+
+        # Include any included installed app directories, e.g. project/app1/templates
+        for app_config in apps.get_app_configs():
+            template_dir = os.path.join(app_config.path, "templates")
+            if os.path.isdir(template_dir):
+                dirs.append(template_dir)
+
+        # Check project root templates, e.g. project/templates
+        base_dir = getattr(settings, "COTTON_BASE_DIR", None)
+        if base_dir is None:
+            base_dir = getattr(settings, "BASE_DIR", None)
+
+        if base_dir is not None:
+            root_template_dir = os.path.join(base_dir, "templates")
+            if os.path.isdir(root_template_dir):
+                dirs.append(root_template_dir)
+
+        return dirs
+
+    def reset(self):
+        """Empty the template cache."""
+        self.cache_handler.reset()
+
+    def get_template_sources(self, template_name):
+        """Return an Origin object pointing to an absolute path in each directory
+        in template_dirs. For security reasons, if a path doesn't lie inside
+        one of the template_dirs it is excluded from the result set."""
+        for template_dir in self.get_dirs():
+            try:
+                name = safe_join(template_dir, template_name)
+            except SuspiciousFileOperation:
+                # The joined path was located outside of this template_dir
+                # (it might be inside another one, so this isn't fatal).
+                continue
+
+            yield Origin(
+                name=name,
+                template_name=template_name,
+                loader=self,
+            )
+
+
+class CottonTemplateCacheHandler:
+    """This mimics the simple template caching mechanism in Django's cached.Loader which acts a decent fallback when
+    the user has not configured the cache loader manually.
+
+    TODO: implement cache warming functionality e.g. to be used at deployment
+    """
+
+    def __init__(self):
+        self.template_cache = {}
+
+    def get_cached_template(self, cache_key):
+        return self.template_cache.get(cache_key)
+
+    def cache_template(self, cache_key, compiled_template):
+        self.template_cache[cache_key] = compiled_template
+
+    def get_cache_key(self, origin):
+        try:
+            cache_key = self.generate_hash([origin.name, str(os.path.getmtime(origin.name))])
+        except FileNotFoundError:
+            raise TemplateDoesNotExist(origin)
+
+        return cache_key
+
+    def generate_hash(self, values):
+        return hashlib.sha1("|".join(values).encode()).hexdigest()
+
+    def reset(self):
+        self.template_cache.clear()

--- a/dj_component/exceptions.py
+++ b/dj_component/exceptions.py
@@ -1,0 +1,2 @@
+class CottonIncompleteDynamicComponentError(Exception):
+    pass

--- a/dj_component/templatetags/__init__.py
+++ b/dj_component/templatetags/__init__.py
@@ -1,0 +1,113 @@
+import ast
+from collections.abc import Mapping
+from typing import Set, Any, Dict, List
+
+from django.template import Variable, TemplateSyntaxError, Context
+from django.template.base import VariableDoesNotExist, Template
+from django.utils.safestring import mark_safe
+
+from dj_component.utils import ensure_quoted
+
+
+class UnprocessableDynamicAttr(Exception):
+    pass
+
+
+class DynamicAttr:
+    def __init__(self, value: str, is_cvar=False):
+        self.value = value
+        self._is_cvar = is_cvar
+        self._resolved_value = None
+
+    def resolve(self, context: Context) -> Any:
+        if self._resolved_value is not None:
+            return self._resolved_value
+
+        resolvers = [
+            self._resolve_as_variable,
+            self._resolve_as_boolean,
+            self._resolve_as_template,
+            self._resolve_as_literal,
+        ]
+
+        for resolver in resolvers:
+            try:
+                # noinspection PyArgumentList
+                self._resolved_value = resolver(context)
+                return self._resolved_value
+            except (VariableDoesNotExist, TemplateSyntaxError, ValueError, SyntaxError):
+                continue
+
+        raise UnprocessableDynamicAttr
+
+    def _resolve_as_variable(self, context):
+        return Variable(self.value).resolve(context)
+
+    def _resolve_as_boolean(self, _):
+        if self.value == "":
+            return True
+        raise ValueError
+
+    def _resolve_as_template(self, context):
+        template = Template(self.value)
+        rendered_value = template.render(context)
+        if rendered_value != self.value:
+            return rendered_value
+        raise TemplateSyntaxError
+
+    def _resolve_as_literal(self, _):
+        return ast.literal_eval(self.value)
+
+
+class Attrs(Mapping):
+    def __init__(self, attrs: Dict[str, Any]):
+        self._attrs = attrs
+        self._exclude_from_str: Set[str] = set()
+        self._unprocessable: List[str] = []
+
+    def __str__(self):
+        return mark_safe(
+            " ".join(
+                f"{k}" if v is True else f"{k}={ensure_quoted(v)}"
+                for k, v in self._attrs.items()
+                if k not in self._exclude_from_str
+            )
+        )
+
+    def __getitem__(self, key):
+        return self._attrs[key]
+
+    def __setitem__(self, key, value):
+        self._attrs[key] = value
+
+    def __iter__(self):
+        return iter(self._attrs)
+
+    def __len__(self):
+        return len(self._attrs)
+
+    def items(self):
+        return self._attrs.items()
+
+    def keys(self):
+        return self._attrs.keys()
+
+    def values(self):
+        return self._attrs.values()
+
+    # Custom methods to allow modifications
+    @property
+    def dict(self):
+        return self._attrs
+
+    def unprocessable(self, key):
+        self._unprocessable.append(key)
+
+    def exclude_unprocessable(self):
+        return {k: v for k, v in self._attrs.items() if k not in self._unprocessable}
+
+    def exclude_from_string_output(self, key):
+        self._exclude_from_str.add(key)
+
+    def make_attrs_accessible(self):
+        return {k.replace("-", "_"): v for k, v in self._attrs.items()}

--- a/dj_component/templatetags/_attr.py
+++ b/dj_component/templatetags/_attr.py
@@ -1,0 +1,42 @@
+from django.template import Library
+from django.template.base import (
+    Node,
+    TemplateSyntaxError,
+)
+from django.utils.safestring import mark_safe
+
+from dj_component.templatetags import UnprocessableDynamicAttr, DynamicAttr
+from dj_component.utils import get_cotton_data
+
+register = Library()
+
+
+def cotton_attr(parser, token):
+    bits = token.split_contents()[1:]
+    if len(bits) < 1:
+        raise TemplateSyntaxError("cotton complex-attr must include a 'name'")
+
+    nodelist = parser.parse(("endattr",))
+    parser.delete_first_token()
+    return ComplexAttrNode(bits[0], nodelist)
+
+
+class ComplexAttrNode(Node):
+    def __init__(self, attr_name, nodelist):
+        self.attr_name = attr_name
+        self.nodelist = nodelist
+
+    def render(self, context):
+        cotton_data = get_cotton_data(context)
+        if cotton_data["stack"]:
+            content = self.nodelist.render(context)
+            if self.attr_name.startswith(":"):
+                key = self.attr_name[1:]
+                try:
+                    cotton_data["stack"][-1]["attrs"][key] = DynamicAttr(content).resolve(context)
+                except UnprocessableDynamicAttr:
+                    cotton_data["stack"][-1]["attrs"].unprocessable(key)
+            else:
+                # just template partial
+                cotton_data["stack"][-1]["attrs"][self.attr_name] = mark_safe(content)
+        return ""

--- a/dj_component/templatetags/_component.py
+++ b/dj_component/templatetags/_component.py
@@ -1,0 +1,218 @@
+import functools
+from typing import Union
+
+from django.conf import settings
+from django.template import Library, TemplateDoesNotExist
+from django.template.base import (
+    Node,
+)
+from django.template.context import Context, RequestContext
+from django.template.loader import get_template
+
+from dj_component.utils import get_cotton_data
+from dj_component.exceptions import CottonIncompleteDynamicComponentError
+from dj_component.templatetags import Attrs, DynamicAttr, UnprocessableDynamicAttr
+
+register = Library()
+
+
+class CottonComponentNode(Node):
+    def __init__(self, component_name, nodelist, attrs, only):
+        self.component_name = component_name
+        self.nodelist = nodelist
+        self.attrs = attrs
+        self.template_cache = {}
+        self.only = only
+
+    def render(self, context):
+        cotton_data = get_cotton_data(context)
+
+        # Push a new component onto the stack
+        component_data = {
+            "key": self.component_name,
+            "attrs": Attrs({}),
+            "slots": {},
+        }
+        cotton_data["stack"].append(component_data)
+
+        # Process simple attributes and boolean attributes
+        for key, value in self.attrs.items():
+            value = self._strip_quotes_safely(value)
+            if value is True:  # Boolean attribute
+                component_data["attrs"][key] = True
+            elif key.startswith("::"):  # Escaping 1 colon e.g for shorthand alpine
+                key = key[1:]
+                component_data["attrs"][key] = value
+            elif key.startswith(":"):
+                key = key[1:]
+                try:
+                    component_data["attrs"][key] = DynamicAttr(value).resolve(context)
+                except UnprocessableDynamicAttr:
+                    component_data["attrs"].unprocessable(key)
+            else:
+                component_data["attrs"][key] = value
+
+        # Render the nodelist to process any slot tags and vars
+        default_slot = self.nodelist.render(context)
+
+        # Prepare the cotton-specific data
+        component_state = {
+            **component_data["slots"],
+            **component_data["attrs"].make_attrs_accessible(),
+            "attrs": component_data["attrs"],
+            "slot": default_slot,
+            "cotton_data": cotton_data,
+        }
+
+        template = self._get_cached_template(context, component_data["attrs"])
+
+        if self.only:
+            # Complete isolation
+            output = template.render(Context(component_state))
+        else:
+            if getattr(settings, "COTTON_ENABLE_CONTEXT_ISOLATION", False) is True:
+                # Default - partial isolation
+                new_context = self._create_partial_context(context, component_state)
+                output = template.render(new_context)
+            else:
+                # Legacy - no isolation
+                with context.push(component_state):
+                    output = template.render(context)
+
+        cotton_data["stack"].pop()
+
+        return output
+
+    def _get_cached_template(self, context, attrs):
+        cache = context.render_context.get(self)
+        if cache is None:
+            cache = context.render_context[self] = {}
+
+        template_path = self._generate_component_template_path(self.component_name, attrs.get("is"))
+
+        if template_path in cache:
+            return cache[template_path]
+
+        # Try to get the primary template
+        try:
+            template = get_template(template_path)
+            if hasattr(template, "template"):
+                template = template.template
+            cache[template_path] = template
+            return template
+        except TemplateDoesNotExist:
+            # If the primary template doesn't exist, try the fallback path (index.html)
+            fallback_path = template_path.rsplit(".html", 1)[0] + "/index.html"
+
+            # Check if the fallback template is already cached
+            if fallback_path in cache:
+                return cache[fallback_path]
+
+            # Try to get the fallback template
+            template = get_template(fallback_path)
+            if hasattr(template, "template"):
+                template = template.template
+            cache[fallback_path] = template
+            return template
+
+    def _create_partial_context(self, original_context, component_state):
+        # Get the request object from the original context
+        request = original_context.get("request")
+
+        if request:
+            # Create a new RequestContext
+            new_context = RequestContext(request)
+
+            # Add the component_state to the new context
+            new_context.update(component_state)
+        else:
+            # If there's no request object, create a simple Context
+            new_context = Context(component_state)
+
+        return new_context
+
+    @staticmethod
+    @functools.lru_cache(maxsize=400)
+    def _generate_component_template_path(component_name: str, is_: Union[str, None]) -> str:
+        """Generate the path to the template for the given component name."""
+        if component_name == "component":
+            if is_ is None:
+                raise CottonIncompleteDynamicComponentError(
+                    'Cotton error: "<c-component>" should be accompanied by an "is" attribute.'
+                )
+            component_name = is_
+
+        component_tpl_path = component_name.replace(".", "/")
+
+        # Cotton by default will look for snake_case version of comp names. This can be configured to allow hyphenated names.
+        snaked_cased_named = getattr(settings, "COTTON_SNAKE_CASED_NAMES", True)
+        if snaked_cased_named:
+            component_tpl_path = component_tpl_path.replace("-", "_")
+
+        cotton_dir = getattr(settings, "COTTON_DIR", "components")
+        return f"{cotton_dir}/{component_tpl_path}.html"
+
+    @staticmethod
+    def _strip_quotes_safely(value):
+        if type(value) is str and value.startswith('"') and value.endswith('"'):
+            return value[1:-1]
+        return value
+
+
+def cotton_component(parser, token):
+    """
+    Parse a cotton component tag and return a CottonComponentNode.
+
+    It accepts spaces inside quoted attributes for example if we want to pass valid json that contains spaces in values.
+
+    @TODO Add support here for 'complex' attributes so we can eventually remove the need for the 'attr' tag. The idea
+     here is to render `{{` and `{%` blocks in tags.
+    """
+    bits = token.split_contents()[1:]
+    component_name = bits[0]
+    attrs = {}
+    only = False
+
+    current_key = None
+    current_value = []
+
+    for bit in bits[1:]:
+        if bit == "only":
+            only = True
+            continue
+
+        if "=" in bit:
+            # If we were building a previous value, store it
+            if current_key:
+                attrs[current_key] = " ".join(current_value)
+                current_value = []
+
+            # Start new key-value pair
+            key, value = bit.split("=", 1)
+            if value.startswith(("'", '"')):
+                if value.endswith(("'", '"')) and value[0] == value[-1]:
+                    # Complete quoted value
+                    attrs[key] = value
+                else:
+                    # Start of quoted value
+                    current_key = key
+                    current_value = [value]
+            else:
+                # Simple unquoted value
+                attrs[key] = value
+        else:
+            if current_key:
+                # Continue building quoted value
+                current_value.append(bit)
+            else:
+                # Boolean attribute
+                attrs[bit] = True
+
+    # Store any final value being built
+    if current_key:
+        attrs[current_key] = " ".join(current_value)
+
+    nodelist = parser.parse(("endc",))
+    parser.delete_first_token()
+
+    return CottonComponentNode(component_name, nodelist, attrs, only)

--- a/dj_component/templatetags/_slot.py
+++ b/dj_component/templatetags/_slot.py
@@ -1,0 +1,35 @@
+from django.template import Library
+from django.template.base import (
+    Node,
+    TemplateSyntaxError,
+)
+from django.utils.safestring import mark_safe
+
+from dj_component.utils import get_cotton_data
+
+register = Library()
+
+
+def cotton_slot(parser, token):
+    bits = token.split_contents()[1:]
+    if len(bits) < 1:
+        raise TemplateSyntaxError("cotton slot tag must include a 'name'")
+
+    nodelist = parser.parse(("endslot",))
+    parser.delete_first_token()
+    return CottonSlotNode(bits[0], nodelist)
+
+
+class CottonSlotNode(Node):
+    def __init__(self, slot_name, nodelist):
+        self.slot_name = slot_name
+        self.nodelist = nodelist
+
+    def render(self, context):
+        cotton_data = get_cotton_data(context)
+        if cotton_data["stack"]:
+            content = self.nodelist.render(context)
+            cotton_data["stack"][-1]["slots"][self.slot_name] = mark_safe(content)
+        else:
+            raise TemplateSyntaxError("<slot /> tag must be used inside a component")
+        return ""

--- a/dj_component/templatetags/_vars.py
+++ b/dj_component/templatetags/_vars.py
@@ -1,0 +1,65 @@
+from typing import List
+
+from django.template.base import (
+    Variable,
+    VariableDoesNotExist,
+    Node,
+)
+
+from dj_component.templatetags import DynamicAttr, UnprocessableDynamicAttr, Attrs
+from dj_component.utils import get_cotton_data
+
+
+class CottonVarsNode(Node):
+    def __init__(self, var_dict, empty_vars: List, nodelist):
+        self.var_dict = var_dict
+        self.empty_vars = empty_vars
+        self.nodelist = nodelist
+
+    def render(self, context):
+        cotton_data = get_cotton_data(context)
+
+        if cotton_data["stack"]:
+            current_component = cotton_data["stack"][-1]
+            attrs = current_component["attrs"]
+        else:
+            attrs = Attrs({})
+
+        vars = {}
+
+        for key, value in self.var_dict.items():
+            if key not in attrs.exclude_unprocessable():
+                if key.startswith(":"):
+                    try:
+                        vars[key[1:]] = DynamicAttr(value, is_cvar=True).resolve(context)
+                    except UnprocessableDynamicAttr:
+                        pass
+                else:
+                    attrs[key] = value
+            attrs.exclude_from_string_output(key)
+
+        # Process cvars without values
+        for empty_var in self.empty_vars:
+            attrs.exclude_from_string_output(empty_var)
+
+        with context.push({**vars, **attrs.make_attrs_accessible(), "attrs": attrs}):
+            output = self.nodelist.render(context)
+
+        return output
+
+
+def cotton_cvars(parser, token):
+    bits = token.split_contents()[1:]
+    var_dict = {}
+    empty_vars = []
+    for bit in bits:
+        try:
+            key, value = bit.split("=")
+            var_dict[key] = value.strip("\"'")
+        except ValueError:
+            empty_vars.append(bit)
+
+    nodelist = parser.parse(("endvars",))
+    parser.delete_first_token()
+
+    return CottonVarsNode(var_dict, empty_vars, nodelist)

--- a/dj_component/templatetags/cotton.py
+++ b/dj_component/templatetags/cotton.py
@@ -1,0 +1,31 @@
+from django import template
+from django.utils.html import format_html_join
+
+from dj_component.templatetags._component import cotton_component
+from dj_component.templatetags._vars import cotton_cvars
+from dj_component.templatetags._slot import cotton_slot
+from dj_component.templatetags._attr import cotton_attr
+
+register = template.Library()
+register.tag("c", cotton_component)
+register.tag("slot", cotton_slot)
+register.tag("vars", cotton_cvars)
+register.tag("attr", cotton_attr)
+
+
+@register.filter
+def merge(attrs, args):
+    # attrs is expected to be a dictionary of existing attributes
+    # args is a string of additional attributes to merge, e.g., "class:extra-class"
+    for arg in args.split(","):
+        key, value = arg.split(":", 1)
+        if key in attrs:
+            attrs[key] = value + " " + attrs[key]
+        else:
+            attrs[key] = value
+    return format_html_join(" ", '{0}="{1}"', attrs.items())
+
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)

--- a/dj_component/urls.py
+++ b/dj_component/urls.py
@@ -1,0 +1,13 @@
+from . import views
+from django.urls import path
+from django.views.generic import TemplateView
+
+app_name = "django_cotton"
+
+
+urlpatterns = [
+    path("include", TemplateView.as_view(template_name="cotton_include.html")),
+    path("test/compiled-cotton", views.compiled_cotton_test_view),
+    path("test/native-extends", views.native_extends_test_view),
+    path("test/native-include", views.native_include_test_view),
+]

--- a/dj_component/utils.py
+++ b/dj_component/utils.py
@@ -1,0 +1,26 @@
+import ast
+
+
+def eval_string(value):
+    """
+    Evaluate a string representation of a constant, list, or dictionary to the actual Python object.
+    """
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return value
+
+
+def ensure_quoted(value):
+    if isinstance(value, str):
+        if value.startswith('{"') and value.endswith("}"):
+            return f"'{value}'"  # use single quotes for json-like strings
+        elif value.startswith('"') and value.endswith('"'):
+            return value  # already quoted
+    return f'"{value}"'  # default to double quotes
+
+
+def get_cotton_data(context):
+    if "cotton_data" not in context:
+        context["cotton_data"] = {"stack": [], "vars": {}}
+    return context["cotton_data"]

--- a/dj_component/views.py
+++ b/dj_component/views.py
@@ -1,0 +1,14 @@
+from django.shortcuts import render
+
+
+# benchmarks
+def compiled_cotton_test_view(request):
+    return render(request, "compiled_cotton_test.html")
+
+
+def native_extends_test_view(request):
+    return render(request, "native_extends_test.html")
+
+
+def native_include_test_view(request):
+    return render(request, "native_include_test.html")

--- a/dj_component/wsgi.py
+++ b/dj_component/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for django_cotton project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example_project.settings")
+
+application = get_wsgi_application()


### PR DESCRIPTION
…te tags

- Renamed `cotton_django` to `dj_component`
- Implemented custom template tag compiler for <dj-button>
- Components now render from `templates/components/`
- Supports slot-based content injection